### PR TITLE
#7 Store watch time entries on a local DB on the device

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,9 @@ android {
         propertiesFileName = "secrets.properties"
         defaultPropertiesFileName = "secrets.defaults.properties"
     }
+    ksp {
+        arg("room.schemaLocation", "$projectDir/schemas")
+    }
 }
 
 dependencies {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,9 @@ dependencies {
 
     implementation(libs.coil.compose)
 
+    implementation(libs.room.runtime)
+    ksp(libs.room.ksp)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     implementation(libs.coil.compose)
 
     implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
     ksp(libs.room.ksp)
 
     testImplementation(libs.junit)

--- a/app/schemas/de.htwk.watchtime.database.WatchtimeDatabase/2.json
+++ b/app/schemas/de.htwk.watchtime.database.WatchtimeDatabase/2.json
@@ -1,0 +1,158 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "46c328b09d652dea782a84042e5ae75f",
+    "entities": [
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` INTEGER NOT NULL, `seriesCompleted` INTEGER NOT NULL, PRIMARY KEY(`seriesId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesCompleted",
+            "columnName": "seriesCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`episodeId` INTEGER NOT NULL, `seriesId` INTEGER NOT NULL, `seasonNumber` INTEGER NOT NULL, `runtime` INTEGER, PRIMARY KEY(`episodeId`))",
+        "fields": [
+          {
+            "fieldPath": "episodeId",
+            "columnName": "episodeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonNumber",
+            "columnName": "seasonNumber",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "runtime",
+            "columnName": "runtime",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "episodeId"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "userWatchtime",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`watchtimeEntry` INTEGER PRIMARY KEY AUTOINCREMENT, `seriesId` INTEGER NOT NULL, `episodeId` INTEGER NOT NULL, `dateWatched` INTEGER NOT NULL, FOREIGN KEY(`seriesId`) REFERENCES `series`(`seriesId`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`episodeId`) REFERENCES `episodes`(`episodeId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "watchtimeEntry",
+            "columnName": "watchtimeEntry",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episodeId",
+            "columnName": "episodeId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateWatched",
+            "columnName": "dateWatched",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "watchtimeEntry"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_userWatchtime_seriesId",
+            "unique": false,
+            "columnNames": [
+              "seriesId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_userWatchtime_seriesId` ON `${TABLE_NAME}` (`seriesId`)"
+          },
+          {
+            "name": "index_userWatchtime_episodeId",
+            "unique": false,
+            "columnNames": [
+              "episodeId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_userWatchtime_episodeId` ON `${TABLE_NAME}` (`episodeId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "series",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "seriesId"
+            ],
+            "referencedColumns": [
+              "seriesId"
+            ]
+          },
+          {
+            "table": "episodes",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "episodeId"
+            ],
+            "referencedColumns": [
+              "episodeId"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '46c328b09d652dea782a84042e5ae75f')"
+    ]
+  }
+}

--- a/app/src/main/java/de/htwk/watchtime/data/ExtendedSeries.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/ExtendedSeries.kt
@@ -10,3 +10,12 @@ data class ExtendedSeries(
     val description: String?,
     val genres: List<Genre>,
 )
+
+fun ExtendedSeries.toSeries(): Series {
+    return Series(
+        name = name,
+        id = id,
+        year = year,
+        imageUrl = imageUrl
+    )
+}

--- a/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
@@ -4,13 +4,12 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import java.util.Date
 
-@Entity
+@Entity(tableName="episodes")
 data class EpisodeDbEntry(
     @PrimaryKey
     val episodeId: Int,
     val seriesId: Int,
     val seasonNumber: Int,
     val runtime: Int?,
-    val watched: Boolean,
     val dateWatched: Date
 )

--- a/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
@@ -1,0 +1,16 @@
+package de.htwk.watchtime.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity
+data class EpisodeDbEntry(
+    @PrimaryKey
+    val episodeId: Int,
+    val seriesId: Int,
+    val seasonNumber: Int,
+    val runtime: Int?,
+    val watched: Boolean,
+    val dateWatched: Date
+)

--- a/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
@@ -11,5 +11,5 @@ data class EpisodeDbEntry(
     val seriesId: Int,
     val seasonNumber: Int,
     val runtime: Int?,
-    val dateWatched: Date
+    val dateWatched: Date?
 )

--- a/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/EpisodeDbEntry.kt
@@ -2,7 +2,6 @@ package de.htwk.watchtime.data.db
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.util.Date
 
 @Entity(tableName="episodes")
 data class EpisodeDbEntry(
@@ -11,5 +10,4 @@ data class EpisodeDbEntry(
     val seriesId: Int,
     val seasonNumber: Int,
     val runtime: Int?,
-    val dateWatched: Date?
 )

--- a/app/src/main/java/de/htwk/watchtime/data/db/SeriesDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/SeriesDbEntry.kt
@@ -1,0 +1,12 @@
+package de.htwk.watchtime.data.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "series")
+data class SeriesDbEntry(
+    @PrimaryKey
+    val seriesId: Int,
+    val seasonIdsCompleted: Set<Int>,
+    val seriesCompleted: Boolean,
+)

--- a/app/src/main/java/de/htwk/watchtime/data/db/SeriesDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/SeriesDbEntry.kt
@@ -7,6 +7,5 @@ import androidx.room.PrimaryKey
 data class SeriesDbEntry(
     @PrimaryKey
     val seriesId: Int,
-    val seasonIdsCompleted: Set<Int>,
     val seriesCompleted: Boolean,
 )

--- a/app/src/main/java/de/htwk/watchtime/data/db/UserWatchtimeDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/UserWatchtimeDbEntry.kt
@@ -1,0 +1,26 @@
+package de.htwk.watchtime.data.db
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName="userWatchtime",
+    foreignKeys = [ForeignKey(
+        entity = SeriesDbEntry::class,
+        parentColumns = arrayOf("seriesId"),
+        childColumns = arrayOf("seriesId"),
+        onDelete = ForeignKey.CASCADE
+    ), ForeignKey(
+        entity = EpisodeDbEntry::class,
+        parentColumns = arrayOf("episodeId"),
+        childColumns = arrayOf("episodeId"),
+        onDelete = ForeignKey.CASCADE
+    )]
+)
+data class UserWatchtimeDbEntry(
+    @PrimaryKey(autoGenerate = true)
+    val watchtimeEntry: Int,
+    val seriesId: Int,
+    val episodeId: Int,
+)

--- a/app/src/main/java/de/htwk/watchtime/data/db/UserWatchtimeDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/UserWatchtimeDbEntry.kt
@@ -2,10 +2,11 @@ package de.htwk.watchtime.data.db
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
-    tableName="userWatchtime",
+    tableName = "userWatchtime",
     foreignKeys = [ForeignKey(
         entity = SeriesDbEntry::class,
         parentColumns = arrayOf("seriesId"),
@@ -16,7 +17,11 @@ import androidx.room.PrimaryKey
         parentColumns = arrayOf("episodeId"),
         childColumns = arrayOf("episodeId"),
         onDelete = ForeignKey.CASCADE
-    )]
+    )],
+    indices = [
+        Index(value = ["seriesId"]),
+        Index(value = ["episodeId"]),
+    ]
 )
 data class UserWatchtimeDbEntry(
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/de/htwk/watchtime/data/db/UserWatchtimeDbEntry.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/db/UserWatchtimeDbEntry.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import java.util.Date
 
 @Entity(
     tableName = "userWatchtime",
@@ -25,7 +26,8 @@ import androidx.room.PrimaryKey
 )
 data class UserWatchtimeDbEntry(
     @PrimaryKey(autoGenerate = true)
-    val watchtimeEntry: Int,
+    val watchtimeEntry: Int? = null,
     val seriesId: Int,
     val episodeId: Int,
+    val dateWatched: Date
 )

--- a/app/src/main/java/de/htwk/watchtime/data/uiState/HomeScreenUiState.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/uiState/HomeScreenUiState.kt
@@ -1,0 +1,8 @@
+package de.htwk.watchtime.data.uiState
+
+import de.htwk.watchtime.data.Series
+
+data class HomeScreenUiState(
+    val series: List<Series>,
+    val continueWatchingList: List<Series>
+)

--- a/app/src/main/java/de/htwk/watchtime/database/Converters.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/Converters.kt
@@ -1,0 +1,17 @@
+package de.htwk.watchtime.database
+
+import androidx.room.TypeConverter
+import java.util.Date
+
+class Converters {
+    @TypeConverter
+    fun fromTimestamp(value: Long?): Date? {
+        return value?.let { Date(it) }
+    }
+
+    @TypeConverter
+    fun dateToTimestamp(date: Date?): Long? {
+        return date?.time
+    }
+
+}

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -12,6 +12,7 @@ interface LocalWatchtimeDataSource {
     suspend fun insertNewEpisode(episode: EpisodeDbEntry)
     suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
     suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
+    suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
 }
 
 class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
@@ -43,5 +44,10 @@ class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
     override suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int) {
         watchtimeDao.deleteWatchtimeEntry(seriesId, episodeId)
     }
+
+    override suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean) {
+        watchtimeDao.updateSeriesCompletion(seriesId = seriesId, completed = completed)
+    }
+
 }
 

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -1,15 +1,50 @@
 package de.htwk.watchtime.database
 
+import de.htwk.watchtime.data.db.EpisodeDbEntry
 import de.htwk.watchtime.data.db.SeriesDbEntry
+import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
 
 interface LocalWatchtimeDataSource {
-    suspend fun getSeriesWatchtime(seriesId: Int): SeriesDbEntry
+    suspend fun getSeries(seriesId: Int): SeriesDbEntry
+    suspend fun getEpisode(episodeId: Int): EpisodeDbEntry
+    suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int>
+
+    suspend fun insertSeries(series: SeriesDbEntry)
+    suspend fun insertEpisode(episode: EpisodeDbEntry)
+    suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
+
+    suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
 
 }
 
-class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao): LocalWatchtimeDataSource {
-    override suspend fun getSeriesWatchtime(seriesId: Int): SeriesDbEntry {
+class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
+    LocalWatchtimeDataSource {
+    override suspend fun getSeries(seriesId: Int): SeriesDbEntry {
         return watchtimeDao.getSeries(seriesId)
+    }
+
+    override suspend fun getEpisode(episodeId: Int): EpisodeDbEntry {
+        return watchtimeDao.getEpisode(episodeId)
+    }
+
+    override suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int> {
+        return watchtimeDao.getWatchedEpisodeIds(seriesId)
+    }
+
+    override suspend fun insertEpisode(episode: EpisodeDbEntry) {
+        watchtimeDao.insertEpisode(episode)
+    }
+
+    override suspend fun insertSeries(series: SeriesDbEntry) {
+        watchtimeDao.insertSeries(series)
+    }
+
+    override suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
+        watchtimeDao.insertWatchtimeEntry(watchtimeEntry)
+    }
+
+    override suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
+        watchtimeDao.deleteWatchtimeEntry(watchtimeEntry)
     }
 }
 

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -1,0 +1,15 @@
+package de.htwk.watchtime.database
+
+import de.htwk.watchtime.data.db.SeriesDbEntry
+
+interface LocalWatchtimeDataSource {
+    suspend fun getSeriesWatchtime(seriesId: Int): SeriesDbEntry
+
+}
+
+class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao): LocalWatchtimeDataSource {
+    override suspend fun getSeriesWatchtime(seriesId: Int): SeriesDbEntry {
+        return watchtimeDao.getSeries(seriesId)
+    }
+}
+

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -5,25 +5,23 @@ import de.htwk.watchtime.data.db.SeriesDbEntry
 import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
 
 interface LocalWatchtimeDataSource {
-    suspend fun getSeries(seriesId: Int): SeriesDbEntry
-    suspend fun getEpisode(episodeId: Int): EpisodeDbEntry
+    suspend fun getSeries(seriesId: Int): SeriesDbEntry?
+    suspend fun getEpisode(episodeId: Int): EpisodeDbEntry?
     suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int>
-
     suspend fun insertSeries(series: SeriesDbEntry)
-    suspend fun insertEpisode(episode: EpisodeDbEntry)
+    suspend fun insertNewEpisode(episode: EpisodeDbEntry)
     suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
-
     suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
 
 }
 
 class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
     LocalWatchtimeDataSource {
-    override suspend fun getSeries(seriesId: Int): SeriesDbEntry {
+    override suspend fun getSeries(seriesId: Int): SeriesDbEntry? {
         return watchtimeDao.getSeries(seriesId)
     }
 
-    override suspend fun getEpisode(episodeId: Int): EpisodeDbEntry {
+    override suspend fun getEpisode(episodeId: Int): EpisodeDbEntry? {
         return watchtimeDao.getEpisode(episodeId)
     }
 
@@ -31,7 +29,7 @@ class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
         return watchtimeDao.getWatchedEpisodeIds(seriesId)
     }
 
-    override suspend fun insertEpisode(episode: EpisodeDbEntry) {
+    override suspend fun insertNewEpisode(episode: EpisodeDbEntry) {
         watchtimeDao.insertEpisode(episode)
     }
 

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -3,6 +3,7 @@ package de.htwk.watchtime.database
 import de.htwk.watchtime.data.db.EpisodeDbEntry
 import de.htwk.watchtime.data.db.SeriesDbEntry
 import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
+import java.util.Date
 
 interface LocalWatchtimeDataSource {
     suspend fun getSeries(seriesId: Int): SeriesDbEntry?
@@ -12,6 +13,7 @@ interface LocalWatchtimeDataSource {
     suspend fun insertNewEpisode(episode: EpisodeDbEntry)
     suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
     suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
+    suspend fun modifyWatchtimeDate(episodeId: Int, dateWatched: Date)
 
 }
 
@@ -43,6 +45,10 @@ class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
 
     override suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
         watchtimeDao.deleteWatchtimeEntry(watchtimeEntry)
+    }
+
+    override suspend fun modifyWatchtimeDate(episodeId: Int, dateWatched: Date) {
+        TODO("Not yet implemented")
     }
 }
 

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -13,6 +13,7 @@ interface LocalWatchtimeDataSource {
     suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
     suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
     suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
+    suspend fun getStartedSeriesIds(): List<Int>
 }
 
 class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
@@ -49,5 +50,8 @@ class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
         watchtimeDao.updateSeriesCompletion(seriesId = seriesId, completed = completed)
     }
 
+    override suspend fun getStartedSeriesIds(): List<Int> {
+        return watchtimeDao.getStartedSeriesIds()
+    }
 }
 

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -3,7 +3,6 @@ package de.htwk.watchtime.database
 import de.htwk.watchtime.data.db.EpisodeDbEntry
 import de.htwk.watchtime.data.db.SeriesDbEntry
 import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
-import java.util.Date
 
 interface LocalWatchtimeDataSource {
     suspend fun getSeries(seriesId: Int): SeriesDbEntry?
@@ -12,9 +11,7 @@ interface LocalWatchtimeDataSource {
     suspend fun insertSeries(series: SeriesDbEntry)
     suspend fun insertNewEpisode(episode: EpisodeDbEntry)
     suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
-    suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
-    suspend fun modifyWatchtimeDate(episodeId: Int, dateWatched: Date)
-
+    suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
 }
 
 class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
@@ -43,12 +40,8 @@ class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
         watchtimeDao.insertWatchtimeEntry(watchtimeEntry)
     }
 
-    override suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
-        watchtimeDao.deleteWatchtimeEntry(watchtimeEntry)
-    }
-
-    override suspend fun modifyWatchtimeDate(episodeId: Int, dateWatched: Date) {
-        TODO("Not yet implemented")
+    override suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int) {
+        watchtimeDao.deleteWatchtimeEntry(seriesId, episodeId)
     }
 }
 

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
@@ -29,4 +29,7 @@ interface WatchtimeDao {
 
     @Query("DELETE FROM userWatchtime WHERE seriesId == :seriesId AND episodeId == :episodeId ")
     suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
+
+    @Query("UPDATE series SET seriesCompleted = :completed WHERE seriesId == :seriesId")
+    suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
@@ -11,9 +11,9 @@ import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
 @Dao
 interface WatchtimeDao {
     @Query("SELECT * FROM series WHERE seriesId == :seriesId")
-    suspend fun getSeries(seriesId: Int): SeriesDbEntry
+    suspend fun getSeries(seriesId: Int): SeriesDbEntry?
     @Query("SELECT * FROM episodes WHERE episodeId == :episodeId")
-    suspend fun getEpisode(episodeId: Int): EpisodeDbEntry
+    suspend fun getEpisode(episodeId: Int): EpisodeDbEntry?
     @Query("SELECT episodeId FROM userwatchtime WHERE seriesId == :seriesId")
     suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int>
 

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
@@ -1,0 +1,15 @@
+package de.htwk.watchtime.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import de.htwk.watchtime.data.db.SeriesDbEntry
+
+@Dao
+interface WatchtimeDao {
+    @Query("SELECT * FROM series WHERE seriesId == :seriesId")
+    suspend fun getSeries(seriesId: Int): SeriesDbEntry
+
+    @Insert
+    suspend fun updateSeries(vararg series: SeriesDbEntry)
+}

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
@@ -1,15 +1,30 @@
 package de.htwk.watchtime.database
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
+import de.htwk.watchtime.data.db.EpisodeDbEntry
 import de.htwk.watchtime.data.db.SeriesDbEntry
+import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
 
 @Dao
 interface WatchtimeDao {
     @Query("SELECT * FROM series WHERE seriesId == :seriesId")
     suspend fun getSeries(seriesId: Int): SeriesDbEntry
+    @Query("SELECT * FROM episodes WHERE episodeId == :episodeId")
+    suspend fun getEpisode(episodeId: Int): EpisodeDbEntry
+    @Query("SELECT episodeId FROM userwatchtime WHERE seriesId == :seriesId")
+    suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int>
+
 
     @Insert
-    suspend fun updateSeries(vararg series: SeriesDbEntry)
+    suspend fun insertSeries(vararg series: SeriesDbEntry)
+    @Insert
+    suspend fun insertEpisode(vararg episode: EpisodeDbEntry)
+    @Insert
+    suspend fun insertWatchtimeEntry(vararg watchtimeEntry: UserWatchtimeDbEntry)
+
+    @Delete
+    suspend fun deleteWatchtimeEntry(vararg watchtimeEntry: UserWatchtimeDbEntry)
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
@@ -1,7 +1,6 @@
 package de.htwk.watchtime.database
 
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import de.htwk.watchtime.data.db.EpisodeDbEntry
@@ -12,19 +11,22 @@ import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
 interface WatchtimeDao {
     @Query("SELECT * FROM series WHERE seriesId == :seriesId")
     suspend fun getSeries(seriesId: Int): SeriesDbEntry?
+
     @Query("SELECT * FROM episodes WHERE episodeId == :episodeId")
     suspend fun getEpisode(episodeId: Int): EpisodeDbEntry?
+
     @Query("SELECT episodeId FROM userwatchtime WHERE seriesId == :seriesId")
     suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int>
 
-
     @Insert
     suspend fun insertSeries(vararg series: SeriesDbEntry)
+
     @Insert
     suspend fun insertEpisode(vararg episode: EpisodeDbEntry)
+
     @Insert
     suspend fun insertWatchtimeEntry(vararg watchtimeEntry: UserWatchtimeDbEntry)
 
-    @Delete
-    suspend fun deleteWatchtimeEntry(vararg watchtimeEntry: UserWatchtimeDbEntry)
+    @Query("DELETE FROM userWatchtime WHERE seriesId == :seriesId AND episodeId == :episodeId ")
+    suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
@@ -32,4 +32,10 @@ interface WatchtimeDao {
 
     @Query("UPDATE series SET seriesCompleted = :completed WHERE seriesId == :seriesId")
     suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
+
+    @Query("SELECT user.seriesId " +
+            "FROM userWatchtime as user JOIN series " +
+            "WHERE user.seriesId == series.seriesId and series.seriesCompleted == 0 " +
+            "GROUP BY user.seriesId")
+    suspend fun getStartedSeriesIds(): List<Int>
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDatabase.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDatabase.kt
@@ -2,9 +2,16 @@ package de.htwk.watchtime.database
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import de.htwk.watchtime.data.db.EpisodeDbEntry
 import de.htwk.watchtime.data.db.SeriesDbEntry
+import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
 
-@Database(entities = [SeriesDbEntry::class], version = 1)
+@Database(
+    entities = [SeriesDbEntry::class, EpisodeDbEntry::class, UserWatchtimeDbEntry::class],
+    version = 1
+)
+@TypeConverters(Converters::class)
 abstract class WatchtimeDatabase : RoomDatabase() {
-    abstract fun seriesDao(): WatchtimeDao
+    abstract fun watchtimeDao(): WatchtimeDao
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDatabase.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDatabase.kt
@@ -9,7 +9,7 @@ import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
 
 @Database(
     entities = [SeriesDbEntry::class, EpisodeDbEntry::class, UserWatchtimeDbEntry::class],
-    version = 1
+    version = 2
 )
 @TypeConverters(Converters::class)
 abstract class WatchtimeDatabase : RoomDatabase() {

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDatabase.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDatabase.kt
@@ -1,0 +1,10 @@
+package de.htwk.watchtime.database
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import de.htwk.watchtime.data.db.SeriesDbEntry
+
+@Database(entities = [SeriesDbEntry::class], version = 1)
+abstract class WatchtimeDatabase : RoomDatabase() {
+    abstract fun seriesDao(): WatchtimeDao
+}

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
@@ -16,6 +16,7 @@ interface WatchtimeRepository {
     suspend fun insertWatchtimeEntry(seriesId: Int, episodeId: Int)
     suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
     suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
+    suspend fun getStartedSeriesIds(): List<Int>
 }
 
 class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDataSource) :
@@ -66,5 +67,9 @@ class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDat
 
     override suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean) {
         watchtimeDataSource.updateSeriesCompletion(seriesId, completed)
+    }
+
+    override suspend fun getStartedSeriesIds(): List<Int> {
+        return watchtimeDataSource.getStartedSeriesIds()
     }
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
@@ -1,0 +1,61 @@
+package de.htwk.watchtime.database
+
+import de.htwk.watchtime.data.Episode
+import de.htwk.watchtime.data.Series
+import de.htwk.watchtime.data.db.EpisodeDbEntry
+import de.htwk.watchtime.data.db.SeriesDbEntry
+import de.htwk.watchtime.data.db.UserWatchtimeDbEntry
+
+interface WatchtimeRepository {
+    suspend fun getSeries(seriesId: Int): SeriesDbEntry?
+    suspend fun getEpisode(episodeId: Int): EpisodeDbEntry?
+    suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int>
+    suspend fun insertNewEpisode(episode: Episode, seriesId: Int)
+    suspend fun insertSeries(series: Series)
+    suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
+    suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
+
+}
+
+class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDataSource) :
+    WatchtimeRepository {
+
+    override suspend fun getSeries(seriesId: Int): SeriesDbEntry? {
+        return watchtimeDataSource.getSeries(seriesId)
+    }
+
+    override suspend fun getEpisode(episodeId: Int): EpisodeDbEntry? {
+        return watchtimeDataSource.getEpisode(episodeId)
+    }
+
+    override suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int> {
+        return watchtimeDataSource.getWatchedEpisodeIds(seriesId)
+    }
+
+    override suspend fun insertNewEpisode(episode: Episode, seriesId: Int) {
+        val dbEpisode = EpisodeDbEntry(
+            episodeId = episode.id,
+            seriesId = seriesId,
+            seasonNumber = episode.seasonNumber,
+            runtime = episode.runtime,
+            dateWatched = null
+        )
+        watchtimeDataSource.insertNewEpisode(dbEpisode)
+    }
+
+    override suspend fun insertSeries(series: Series) {
+        val dbSeries = SeriesDbEntry(
+            seriesId = series.id,
+            seriesCompleted = false
+        )
+        watchtimeDataSource.insertSeries(dbSeries)
+    }
+
+    override suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
+        watchtimeDataSource.insertWatchtimeEntry(watchtimeEntry)
+    }
+
+    override suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
+        watchtimeDataSource.deleteWatchtimeEntry(watchtimeEntry)
+    }
+}

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
@@ -1,5 +1,6 @@
 package de.htwk.watchtime.database
 
+import android.icu.util.Calendar
 import de.htwk.watchtime.data.Episode
 import de.htwk.watchtime.data.Series
 import de.htwk.watchtime.data.db.EpisodeDbEntry
@@ -12,7 +13,7 @@ interface WatchtimeRepository {
     suspend fun getWatchedEpisodeIds(seriesId: Int): List<Int>
     suspend fun insertNewEpisode(episode: Episode, seriesId: Int)
     suspend fun insertSeries(series: Series)
-    suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
+    suspend fun insertWatchtimeEntry(seriesId: Int, episodeId: Int)
     suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
 
 }
@@ -38,7 +39,6 @@ class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDat
             seriesId = seriesId,
             seasonNumber = episode.seasonNumber,
             runtime = episode.runtime,
-            dateWatched = null
         )
         watchtimeDataSource.insertNewEpisode(dbEpisode)
     }
@@ -51,7 +51,12 @@ class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDat
         watchtimeDataSource.insertSeries(dbSeries)
     }
 
-    override suspend fun insertWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
+    override suspend fun insertWatchtimeEntry(seriesId: Int, episodeId: Int) {
+        val watchtimeEntry = UserWatchtimeDbEntry(
+            seriesId = seriesId,
+            episodeId = episodeId,
+            dateWatched = Calendar.getInstance().time
+        )
         watchtimeDataSource.insertWatchtimeEntry(watchtimeEntry)
     }
 

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
@@ -14,7 +14,7 @@ interface WatchtimeRepository {
     suspend fun insertNewEpisode(episode: Episode, seriesId: Int)
     suspend fun insertSeries(series: Series)
     suspend fun insertWatchtimeEntry(seriesId: Int, episodeId: Int)
-    suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry)
+    suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
 
 }
 
@@ -60,7 +60,7 @@ class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDat
         watchtimeDataSource.insertWatchtimeEntry(watchtimeEntry)
     }
 
-    override suspend fun deleteWatchtimeEntry(watchtimeEntry: UserWatchtimeDbEntry) {
-        watchtimeDataSource.deleteWatchtimeEntry(watchtimeEntry)
+    override suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int) {
+        watchtimeDataSource.deleteWatchtimeEntry(seriesId, episodeId)
     }
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
@@ -15,7 +15,7 @@ interface WatchtimeRepository {
     suspend fun insertSeries(series: Series)
     suspend fun insertWatchtimeEntry(seriesId: Int, episodeId: Int)
     suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
-
+    suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
 }
 
 class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDataSource) :
@@ -62,5 +62,9 @@ class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDat
 
     override suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int) {
         watchtimeDataSource.deleteWatchtimeEntry(seriesId, episodeId)
+    }
+
+    override suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean) {
+        watchtimeDataSource.updateSeriesCompletion(seriesId, completed)
     }
 }

--- a/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
+++ b/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
@@ -4,7 +4,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.room.Room
 import de.htwk.watchtime.database.LocalWatchtimeDataSource
 import de.htwk.watchtime.database.LocalWatchtimeDataSourceImpl
+import de.htwk.watchtime.database.WatchtimeDao
 import de.htwk.watchtime.database.WatchtimeDatabase
+import de.htwk.watchtime.database.WatchtimeRepository
+import de.htwk.watchtime.database.WatchtimeRepositoryImpl
 import de.htwk.watchtime.network.RemoteSeriesDataSource
 import de.htwk.watchtime.network.RemoteSeriesDataSourceImpl
 import de.htwk.watchtime.network.SeriesRepository
@@ -22,6 +25,7 @@ val appModule = module {
     singleOf(::RemoteSeriesDataSourceImpl) bind RemoteSeriesDataSource::class
     singleOf(::SeriesRepositoryImpl) bind SeriesRepository::class
     singleOf(::LocalWatchtimeDataSourceImpl) bind LocalWatchtimeDataSource::class
+    singleOf(::WatchtimeRepositoryImpl) bind WatchtimeRepository::class
     singleOf(::SessionManager)
     singleOf(::LocalContext)
     single {
@@ -29,9 +33,12 @@ val appModule = module {
             androidApplication(),
             WatchtimeDatabase::class.java,
             "watchtime-database"
-        )
+        ).build()
     }
-    single { get<WatchtimeDatabase>().seriesDao() }
+    single<WatchtimeDao> {
+        val database = get<WatchtimeDatabase>()
+        database.watchtimeDao()
+    }
     viewModelOf(::HomeViewModel)
     viewModelOf(::DetailsViewModel)
 }

--- a/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
+++ b/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
@@ -1,6 +1,10 @@
 package de.htwk.watchtime.di
 
 import androidx.compose.ui.platform.LocalContext
+import androidx.room.Room
+import de.htwk.watchtime.database.LocalWatchtimeDataSource
+import de.htwk.watchtime.database.LocalWatchtimeDataSourceImpl
+import de.htwk.watchtime.database.WatchtimeDatabase
 import de.htwk.watchtime.network.RemoteSeriesDataSource
 import de.htwk.watchtime.network.RemoteSeriesDataSourceImpl
 import de.htwk.watchtime.network.SeriesRepository
@@ -8,6 +12,7 @@ import de.htwk.watchtime.network.SeriesRepositoryImpl
 import de.htwk.watchtime.network.SessionManager
 import de.htwk.watchtime.ui.screens.shared.DetailsViewModel
 import de.htwk.watchtime.ui.screens.shared.HomeViewModel
+import org.koin.android.ext.koin.androidApplication
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -16,8 +21,17 @@ import org.koin.dsl.module
 val appModule = module {
     singleOf(::RemoteSeriesDataSourceImpl) bind RemoteSeriesDataSource::class
     singleOf(::SeriesRepositoryImpl) bind SeriesRepository::class
+    singleOf(::LocalWatchtimeDataSourceImpl) bind LocalWatchtimeDataSource::class
     singleOf(::SessionManager)
     singleOf(::LocalContext)
+    single {
+        Room.databaseBuilder(
+            androidApplication(),
+            WatchtimeDatabase::class.java,
+            "watchtime-database"
+        )
+    }
+    single { get<WatchtimeDatabase>().seriesDao() }
     viewModelOf(::HomeViewModel)
     viewModelOf(::DetailsViewModel)
 }

--- a/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
+++ b/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
@@ -33,7 +33,7 @@ val appModule = module {
             androidApplication(),
             WatchtimeDatabase::class.java,
             "watchtime-database"
-        ).build()
+        ).fallbackToDestructiveMigration().build()
     }
     single<WatchtimeDao> {
         val database = get<WatchtimeDatabase>()

--- a/app/src/main/java/de/htwk/watchtime/network/SeriesRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/SeriesRepository.kt
@@ -44,12 +44,12 @@ class SeriesRepositoryImpl(
 
         seriesDetails.seasons.forEach { seasonDto ->
             seasonList[seasonDto.seasonNumber] = (
-                Season(
-                    id = seasonDto.id,
-                    seasonNumber = seasonDto.seasonNumber,
-                    episodeIds = mutableListOf(),
-                )
-            )
+                    Season(
+                        id = seasonDto.id,
+                        seasonNumber = seasonDto.seasonNumber,
+                        episodeIds = mutableListOf(),
+                    )
+                    )
         }
 
         seriesDetails.episodes.forEach { episodeDto ->
@@ -75,13 +75,16 @@ class SeriesRepositoryImpl(
             )
         }
 
+        val filteredSeasonList =
+            seasonList.filterKeys { seasonList[it]?.episodeIds?.isNotEmpty() ?: false }
+
         return ExtendedSeries(
             name = seriesDetails.name,
             id = seriesDetails.id,
             year = seriesDetails.year?.substring(0, 4) ?: "unknown",
             imageUrl = seriesDetails.imageUrl,
             episodes = episodeList,
-            seasons = seasonList.toSortedMap(),
+            seasons = filteredSeasonList.toSortedMap(),
             description = seriesDetails.description,
             genres = genreList,
         )

--- a/app/src/main/java/de/htwk/watchtime/ui/MainActivity.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/MainActivity.kt
@@ -3,6 +3,7 @@ package de.htwk.watchtime.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -11,6 +12,7 @@ import de.htwk.watchtime.ui.theme.WatchtimeTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         setContent {

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/DetailsScreen.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/DetailsScreen.kt
@@ -58,7 +58,7 @@ fun DetailsScreen(
     modifier: Modifier = Modifier,
     viewModel: DetailsViewModel = koinViewModel()
 ) {
-    val detailsScreenUiState by viewModel.seriesDetails.collectAsState()
+    val detailsScreenUiState by viewModel.uiState.collectAsState()
 
     DetailsScreen(
         seriesDetails = detailsScreenUiState.seriesDetails,

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/DetailsScreen.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/DetailsScreen.kt
@@ -118,7 +118,6 @@ fun DetailsScreen(
                 .fillMaxSize()
                 .padding(16.dp),
         ) {
-
             LazyColumn {
                 item {
                     CardHeader(

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/HomeScreen.kt
@@ -119,7 +119,7 @@ fun ContinueWatchingCarousel(
     onCardTap: (seriesId: Int) -> Unit = {}
 ) {
     LazyRow(
-        modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)
+        modifier = modifier.fillMaxWidth().padding(start = 2.dp, end = 2.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         items(continueWatchingList) { series ->
             CarouselCard(series, onCardTap = onCardTap)

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -51,11 +52,12 @@ fun HomeScreen(
     onCardTap: (seriesId: Int) -> Unit = {},
     viewModel: HomeViewModel = koinViewModel()
 ) {
-    val seriesList by viewModel.series.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
     HomeScreen(
-        recommendedSeries = seriesList,
-        continueWatchingList = seriesList,
+        recommendedSeries = uiState.series,
+        continueWatchingList = uiState.continueWatchingList,
         onCardTap = onCardTap,
+        refreshContinueWatching = { viewModel.updateContinueWatchingList() },
         modifier = modifier
     )
 }
@@ -65,8 +67,12 @@ fun HomeScreen(
     recommendedSeries: List<Series>,
     continueWatchingList: List<Series>,
     modifier: Modifier = Modifier,
-    onCardTap: (seriesId: Int) -> Unit = {}
+    onCardTap: (seriesId: Int) -> Unit = {},
+    refreshContinueWatching: () -> Unit = {}
 ) {
+    LaunchedEffect(Unit){
+        refreshContinueWatching()
+    }
     LazyColumn(
         modifier = modifier
             .fillMaxSize()
@@ -74,14 +80,19 @@ fun HomeScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        item {
-            HomeScreenTitle(text = stringResource(id = R.string.home_screen_continue_watching_title))
+        if (continueWatchingList.isNotEmpty()) {
+            item {
+                HomeScreenTitle(text = stringResource(id = R.string.home_screen_continue_watching_title))
+            }
+            item {
+                ContinueWatchingCarousel(
+                    continueWatchingList = continueWatchingList,
+                    onCardTap = onCardTap
+                )
+            }
         }
         item {
-            ContinueWatchingCarousel(continueWatchingList = continueWatchingList, onCardTap = onCardTap)
-        }
-        item {
-            HomeScreenTitle(text = stringResource(id = R.string.home_screen_popular_title))
+            HomeScreenTitle(text = stringResource(id = R.string.home_screen_recommended_title))
         }
         items(recommendedSeries) { series ->
             SeriesCard(series = series, onTap = onCardTap)
@@ -139,7 +150,7 @@ fun CarouselCard(
                 textAlign = TextAlign.Center
             )
             AsyncImage(
-                model = "https://artworks.thetvdb.com${series.imageUrl}",
+                model = series.imageUrl,
                 contentDescription = stringResource(id = R.string.home_screen_image_desc),
                 contentScale = ContentScale.Crop
             )

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
@@ -243,10 +243,17 @@ class DetailsViewModel(
     private fun checkIfSeriesIsCompleted() {
         val watchedEpisodes = uiState.value.episodesWatched
         val allEpisodeIds = uiState.value.seriesDetails.episodes.map { it.id }
+        val newCompletionState = watchedEpisodes.containsAll(allEpisodeIds)
+
         _detailsScreenUiState.update { currentState ->
             currentState.copy(
-                seriesCompleted = watchedEpisodes.containsAll(allEpisodeIds)
+                seriesCompleted = newCompletionState
             )
+        }
+
+        // TODO: Optimize, so that DB is only updated if value actually changes
+        viewModelScope.launch {
+            watchtimeRepository.updateSeriesCompletion(seriesId, newCompletionState)
         }
     }
 }

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import de.htwk.watchtime.data.ExtendedSeries
 import de.htwk.watchtime.data.Season
 import de.htwk.watchtime.data.uiState.DetailsScreenUiState
+import de.htwk.watchtime.database.WatchtimeRepository
 import de.htwk.watchtime.network.SeriesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +16,8 @@ import kotlinx.coroutines.launch
 
 class DetailsViewModel(
     savedStateHandle: SavedStateHandle,
-    private val seriesRepository: SeriesRepository
+    private val seriesRepository: SeriesRepository,
+    private val watchtimeRepository: WatchtimeRepository,
 ) : ViewModel() {
     private val seriesId: Int = checkNotNull(savedStateHandle.get<Int>("seriesId"))
 
@@ -48,6 +50,14 @@ class DetailsViewModel(
                     seriesDetails = seriesDetails,
                     selectedSeason = seriesDetails.seasons.keys.first()
                 )
+            }
+
+            // Check if episodes already in DB, if not add them
+            seriesDetails.episodes.forEach { episode ->
+                val dbEpisodeResult = watchtimeRepository.getEpisode(episode.id)
+                if (dbEpisodeResult == null) {
+                    watchtimeRepository.insertNewEpisode(episode, seriesId)
+                }
             }
         }
     }

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/HomeViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import de.htwk.watchtime.data.Series
 import de.htwk.watchtime.data.placeholder.placeHolderSeriesList
+import de.htwk.watchtime.database.WatchtimeRepository
 import de.htwk.watchtime.network.SeriesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,7 +13,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class HomeViewModel(
-    private val seriesRepository: SeriesRepository
+    private val seriesRepository: SeriesRepository,
+    private val watchtimeRepository: WatchtimeRepository,
 ): ViewModel() {
 
     private val _series: MutableStateFlow<List<Series>> = MutableStateFlow(placeHolderSeriesList)
@@ -26,6 +28,14 @@ class HomeViewModel(
         viewModelScope.launch {
             _series.update {
                 seriesRepository.getSeries()
+            }
+
+            // Check if series already in DB, if not add it
+            series.value.forEach { series ->
+                val dbSeriesResult = watchtimeRepository.getSeries(series.id)
+                if (dbSeriesResult == null) {
+                    watchtimeRepository.insertSeries(series)
+                }
             }
         }
     }

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/HomeViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/HomeViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import de.htwk.watchtime.data.Series
 import de.htwk.watchtime.data.placeholder.placeHolderSeriesList
+import de.htwk.watchtime.data.toSeries
+import de.htwk.watchtime.data.uiState.HomeScreenUiState
 import de.htwk.watchtime.database.WatchtimeRepository
 import de.htwk.watchtime.network.SeriesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,27 +17,52 @@ import kotlinx.coroutines.launch
 class HomeViewModel(
     private val seriesRepository: SeriesRepository,
     private val watchtimeRepository: WatchtimeRepository,
-): ViewModel() {
+) : ViewModel() {
 
-    private val _series: MutableStateFlow<List<Series>> = MutableStateFlow(placeHolderSeriesList)
-    val series: StateFlow<List<Series>> = _series.asStateFlow()
+    private val _homeScreenUiState: MutableStateFlow<HomeScreenUiState> = MutableStateFlow(
+        HomeScreenUiState(
+            series = placeHolderSeriesList,
+            continueWatchingList = placeHolderSeriesList
+        )
+    )
+    val uiState: StateFlow<HomeScreenUiState> = _homeScreenUiState.asStateFlow()
 
     init {
         loadSeries()
+        updateContinueWatchingList()
     }
 
     private fun loadSeries() {
         viewModelScope.launch {
-            _series.update {
-                seriesRepository.getSeries()
+            _homeScreenUiState.update { currentState ->
+                currentState.copy(
+                    series = seriesRepository.getSeries()
+                )
             }
 
             // Check if series already in DB, if not add it
-            series.value.forEach { series ->
+            uiState.value.series.forEach { series ->
                 val dbSeriesResult = watchtimeRepository.getSeries(series.id)
                 if (dbSeriesResult == null) {
                     watchtimeRepository.insertSeries(series)
                 }
+            }
+        }
+    }
+
+    fun updateContinueWatchingList() {
+        viewModelScope.launch {
+            val startedSeriesIds = watchtimeRepository.getStartedSeriesIds()
+            val startedSeries = mutableListOf<Series>()
+
+            startedSeriesIds.forEach { seriesId ->
+                startedSeries.add(seriesRepository.getSeriesDetails(seriesId).toSeries())
+            }
+
+            _homeScreenUiState.update { currentState ->
+                currentState.copy(
+                    continueWatchingList = startedSeries
+                )
             }
         }
     }

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/components/WatchtimeTopAppBar.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/components/WatchtimeTopAppBar.kt
@@ -47,7 +47,7 @@ fun WatchtimeTopAppBar(
 private fun AppBarTitle() {
     Text(
         text = stringResource(id = R.string.app_name),
-        style = MaterialTheme.typography.titleLarge,
+        style = MaterialTheme.typography.headlineLarge,
     )
 }
 

--- a/app/src/main/java/de/htwk/watchtime/ui/theme/Theme.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/theme/Theme.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -56,8 +55,7 @@ fun WatchtimeTheme(
     if (!view.isInEditMode) {
       SideEffect {
         val window = (view.context as Activity).window
-        window.statusBarColor = colorScheme.primary.toArgb()
-        WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+        WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
       }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="navigate_stats">Navigate to stats</string>
     <string name="navigate_details">Navigate to details</string>
 
-    <string name="home_screen_popular_title">Popular</string>
+    <string name="home_screen_recommended_title">Recommended</string>
     <string name="home_screen_continue_watching_title">Continue Watching</string>
     <string name="home_screen_image_desc">Series Artwork</string>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-agp = "8.2.0"
+agp = "8.2.1"
 org-jetbrains-kotlin-android = "1.9.10"
 core-ktx = "1.12.0"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
-lifecycle = "2.6.2"
+lifecycle = "2.7.0"
 activity-compose = "1.8.2"
 compose-bom = "2023.10.01"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose", versi
 # Room
 room-ksp = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 
 secrets = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secrets" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ junit = "4.13.2"
 androidx-test-ext-junit = "1.1.5"
 espresso-core = "3.5.1"
 lifecycle = "2.6.2"
-activity-compose = "1.8.0"
+activity-compose = "1.8.2"
 compose-bom = "2023.10.01"
 
 coil = "2.5.0"
@@ -14,9 +14,10 @@ retrofit = "2.9.0"
 moshi = "1.15.0"
 okHttpLoggingInterceptor = "4.11.0"
 ksp = "1.9.10-1.0.13"
-navigation = "2.7.5"
+navigation = "2.7.6"
 koin = "3.5.0"
 secrets = "2.0.1"
+room = "2.6.1"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -52,6 +53,10 @@ moshi-annotationProcessor = { module = "com.squareup.moshi:moshi-kotlin-codegen"
 # Koin
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }
+
+# Room
+room-ksp = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 
 secrets = { module = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin", version.ref = "secrets" }
 


### PR DESCRIPTION
## Summary

Until now, user watch time entries have been discarded after the details screen is left.
This PR implements a local Room Database that stores simple references to Series/Episodes and the corresponding watch time entries.
Watch time entries contain a reference to the watched episode and corresponsing series. Additionally a time stamp is stored for future use (e.g. generating time based graphs based on the entry's date)
