### PR TITLE
#13 Post updated watchtime to Azure Backend

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -98,7 +98,6 @@
                   <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
                 </AND>
               </match>
-              <order>ANDROID_ATTRIBUTE_ORDER</order>
             </rule>
           </section>
           <section>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -2,11 +2,21 @@
 <project version="4">
   <component name="deploymentTargetDropDown">
     <value>
-      <entry key="RoundedSearchBarPreview">
-        <State />
-      </entry>
       <entry key="app">
-        <State />
+        <State>
+          <targetSelectedWithDropDown>
+            <Target>
+              <type value="QUICK_BOOT_TARGET" />
+              <deviceKey>
+                <Key>
+                  <type value="VIRTUAL_DEVICE_PATH" />
+                  <value value="$USER_HOME$/.android/avd/Resizable_Experimental_API_VanillaIceCream.avd" />
+                </Key>
+              </deviceKey>
+            </Target>
+          </targetSelectedWithDropDown>
+          <timeTargetWasSelectedWithDropDown value="2024-02-20T22:47:12.006523600Z" />
+        </State>
       </entry>
     </value>
   </component>

--- a/app/src/main/java/de/htwk/watchtime/data/Event.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/Event.kt
@@ -1,0 +1,24 @@
+package de.htwk.watchtime.data
+
+open class Event<out T>(private val content: T) {
+
+    private var hasBeenHandled = false
+        private set // Allow external read but not write
+
+    /**
+     * Returns the content and prevents its use again.
+     */
+    fun getContentIfNotHandled(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    /**
+     * Returns the content, even if it's already been handled.
+     */
+    fun peekContent(): T = content
+}

--- a/app/src/main/java/de/htwk/watchtime/data/Ranking.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/Ranking.kt
@@ -1,0 +1,7 @@
+package de.htwk.watchtime.data
+
+data class Ranking(
+    val position: Int,
+    val totalWatchtime: Long,
+    val closestNeighbors: List<RankingNeighbor>
+)

--- a/app/src/main/java/de/htwk/watchtime/data/RankingNeighbor.kt
+++ b/app/src/main/java/de/htwk/watchtime/data/RankingNeighbor.kt
@@ -1,0 +1,6 @@
+package de.htwk.watchtime.data
+
+data class RankingNeighbor(
+    val position: Int,
+    val totalWatchtime: Long
+)

--- a/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/LocalWatchtimeDataSource.kt
@@ -14,6 +14,7 @@ interface LocalWatchtimeDataSource {
     suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
     suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
     suspend fun getStartedSeriesIds(): List<Int>
+    suspend fun getTotalWatchtime(): Long
 }
 
 class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
@@ -52,6 +53,10 @@ class LocalWatchtimeDataSourceImpl(private val watchtimeDao: WatchtimeDao) :
 
     override suspend fun getStartedSeriesIds(): List<Int> {
         return watchtimeDao.getStartedSeriesIds()
+    }
+
+    override suspend fun getTotalWatchtime(): Long {
+        return watchtimeDao.getTotalWatchtime()
     }
 }
 

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeDao.kt
@@ -38,4 +38,9 @@ interface WatchtimeDao {
             "WHERE user.seriesId == series.seriesId and series.seriesCompleted == 0 " +
             "GROUP BY user.seriesId")
     suspend fun getStartedSeriesIds(): List<Int>
+
+    @Query("SELECT SUM(episode.runtime) " +
+            "FROM userWatchtime as user JOIN episodes as episode " +
+            "WHERE user.episodeId == episode.episodeId")
+    suspend fun getTotalWatchtime(): Long
 }

--- a/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/database/WatchtimeRepository.kt
@@ -17,6 +17,7 @@ interface WatchtimeRepository {
     suspend fun deleteWatchtimeEntry(seriesId: Int, episodeId: Int)
     suspend fun updateSeriesCompletion(seriesId: Int, completed: Boolean)
     suspend fun getStartedSeriesIds(): List<Int>
+    suspend fun getTotalWatchtime(): Long
 }
 
 class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDataSource) :
@@ -71,5 +72,9 @@ class WatchtimeRepositoryImpl(private val watchtimeDataSource: LocalWatchtimeDat
 
     override suspend fun getStartedSeriesIds(): List<Int> {
         return watchtimeDataSource.getStartedSeriesIds()
+    }
+
+    override suspend fun getTotalWatchtime(): Long {
+        return watchtimeDataSource.getTotalWatchtime()
     }
 }

--- a/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
+++ b/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
@@ -8,10 +8,7 @@ import de.htwk.watchtime.database.WatchtimeDao
 import de.htwk.watchtime.database.WatchtimeDatabase
 import de.htwk.watchtime.database.WatchtimeRepository
 import de.htwk.watchtime.database.WatchtimeRepositoryImpl
-import de.htwk.watchtime.network.ranking.RankingRepository
-import de.htwk.watchtime.network.ranking.RankingRepositoryImpl
-import de.htwk.watchtime.network.ranking.RemoteRankingDataSource
-import de.htwk.watchtime.network.ranking.RemoteRankingDataSourceImpl
+import de.htwk.watchtime.network.ranking.*
 import de.htwk.watchtime.network.series.RemoteSeriesDataSource
 import de.htwk.watchtime.network.series.RemoteSeriesDataSourceImpl
 import de.htwk.watchtime.network.series.SeriesRepository
@@ -34,6 +31,7 @@ val appModule = module {
     singleOf(::RemoteRankingDataSourceImpl) bind RemoteRankingDataSource::class
     singleOf(::RankingRepositoryImpl) bind RankingRepository::class
     singleOf(::SessionManager)
+    singleOf(::DeviceIdManager)
     singleOf(::LocalContext)
     single {
         Room.databaseBuilder(

--- a/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
+++ b/app/src/main/java/de/htwk/watchtime/di/AppModule.kt
@@ -8,11 +8,15 @@ import de.htwk.watchtime.database.WatchtimeDao
 import de.htwk.watchtime.database.WatchtimeDatabase
 import de.htwk.watchtime.database.WatchtimeRepository
 import de.htwk.watchtime.database.WatchtimeRepositoryImpl
-import de.htwk.watchtime.network.RemoteSeriesDataSource
-import de.htwk.watchtime.network.RemoteSeriesDataSourceImpl
-import de.htwk.watchtime.network.SeriesRepository
-import de.htwk.watchtime.network.SeriesRepositoryImpl
-import de.htwk.watchtime.network.SessionManager
+import de.htwk.watchtime.network.ranking.RankingRepository
+import de.htwk.watchtime.network.ranking.RankingRepositoryImpl
+import de.htwk.watchtime.network.ranking.RemoteRankingDataSource
+import de.htwk.watchtime.network.ranking.RemoteRankingDataSourceImpl
+import de.htwk.watchtime.network.series.RemoteSeriesDataSource
+import de.htwk.watchtime.network.series.RemoteSeriesDataSourceImpl
+import de.htwk.watchtime.network.series.SeriesRepository
+import de.htwk.watchtime.network.series.SeriesRepositoryImpl
+import de.htwk.watchtime.network.series.SessionManager
 import de.htwk.watchtime.ui.screens.shared.DetailsViewModel
 import de.htwk.watchtime.ui.screens.shared.HomeViewModel
 import de.htwk.watchtime.ui.screens.shared.SearchViewModel
@@ -27,6 +31,8 @@ val appModule = module {
     singleOf(::SeriesRepositoryImpl) bind SeriesRepository::class
     singleOf(::LocalWatchtimeDataSourceImpl) bind LocalWatchtimeDataSource::class
     singleOf(::WatchtimeRepositoryImpl) bind WatchtimeRepository::class
+    singleOf(::RemoteRankingDataSourceImpl) bind RemoteRankingDataSource::class
+    singleOf(::RankingRepositoryImpl) bind RankingRepository::class
     singleOf(::SessionManager)
     singleOf(::LocalContext)
     single {

--- a/app/src/main/java/de/htwk/watchtime/network/NetworkRequestException.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/NetworkRequestException.kt
@@ -1,0 +1,3 @@
+package de.htwk.watchtime.network
+
+class NetworkRequestException(message: String): Exception(message)

--- a/app/src/main/java/de/htwk/watchtime/network/dto/RankingNeighbor.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/dto/RankingNeighbor.kt
@@ -1,0 +1,17 @@
+package de.htwk.watchtime.network.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class RankingNeighbor (
+    @Json(name = "position") val position: Int,
+    @Json(name = "totalWatchtime") val totalWatchtime: Long
+)
+
+fun RankingNeighbor.toRankingNeighbor(): de.htwk.watchtime.data.RankingNeighbor {
+    return de.htwk.watchtime.data.RankingNeighbor(
+        position = position,
+        totalWatchtime = totalWatchtime
+    )
+}

--- a/app/src/main/java/de/htwk/watchtime/network/dto/RankingRequest.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/dto/RankingRequest.kt
@@ -1,0 +1,10 @@
+package de.htwk.watchtime.network.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class RankingRequest (
+    @Json(name = "userId") val userId: String,
+    @Json(name ="totalWatchtime") val totalWatchtime: Long
+)

--- a/app/src/main/java/de/htwk/watchtime/network/dto/RankingResponse.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/dto/RankingResponse.kt
@@ -1,0 +1,20 @@
+package de.htwk.watchtime.network.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import de.htwk.watchtime.data.Ranking
+
+@JsonClass(generateAdapter = true)
+data class RankingResponse(
+    @Json(name = "position") val position: Int,
+    @Json(name = "totalWatchtime") val totalWatchtime: Long,
+    @Json(name = "closestNeighbors") val closestNeighbors: List<RankingNeighbor>
+)
+
+fun RankingResponse.toRanking(): Ranking {
+    return Ranking(
+        position = position,
+        totalWatchtime = totalWatchtime,
+        closestNeighbors = closestNeighbors.map { it.toRankingNeighbor() }
+    )
+}

--- a/app/src/main/java/de/htwk/watchtime/network/ranking/DeviceIdManager.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/ranking/DeviceIdManager.kt
@@ -1,0 +1,29 @@
+package de.htwk.watchtime.network.ranking
+
+import android.content.Context
+import android.content.SharedPreferences
+import de.htwk.watchtime.R
+import java.util.*
+
+class DeviceIdManager (private val context: Context) {
+    private var prefs: SharedPreferences = context.getSharedPreferences(context.getString(R.string.app_name), Context.MODE_PRIVATE)
+
+    companion object {
+        const val DEVICE_ID = "device_id"
+    }
+
+
+    fun getDeviceId(): String {
+        val deviceId = prefs.getString(DEVICE_ID, null)
+
+        if (deviceId == null) {
+            val editor = prefs.edit()
+            val newDeviceId = UUID.randomUUID().toString()
+            editor.putString(DEVICE_ID, newDeviceId)
+            editor.apply()
+            return newDeviceId
+        }
+
+        return deviceId
+    }
+}

--- a/app/src/main/java/de/htwk/watchtime/network/ranking/RankingApi.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/ranking/RankingApi.kt
@@ -1,0 +1,37 @@
+package de.htwk.watchtime.network.ranking
+
+import de.htwk.watchtime.network.dto.RankingRequest
+import de.htwk.watchtime.network.dto.RankingResponse
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.http.*
+
+interface RankingApi {
+    @GET("ranking/position/{id}")
+    suspend fun getRanking(
+        @Header("Authorization") authHeader: String,
+        @Path("id") id: String
+    ): Response<RankingResponse>
+
+
+    @PUT("ranking/user")
+    suspend fun updateWatchtime(
+        @Header("Authorization") authHeader: String,
+        @Body rankingRequest: RankingRequest
+    ): Response<Void>
+
+    @DELETE("ranking/user/{id}")
+    suspend fun deleteUser(
+        @Header("Authorization") authHeader: String,
+        @Path("id") id: String
+    ): Response<Void>
+
+}
+
+private val retrofit = Retrofit.Builder()
+    .baseUrl("https://func-moco-lufr.azurewebsites.net/api/")
+    .addConverterFactory(MoshiConverterFactory.create())
+    .build()
+
+val rankingApi: RankingApi = retrofit.create(RankingApi::class.java)

--- a/app/src/main/java/de/htwk/watchtime/network/ranking/RankingApi.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/ranking/RankingApi.kt
@@ -17,7 +17,7 @@ interface RankingApi {
 
     @PUT("ranking/user")
     suspend fun updateWatchtime(
-        @Header("Authorization") authHeader: String,
+        @Query("code") functionKey: String,
         @Body rankingRequest: RankingRequest
     ): Response<Void>
 

--- a/app/src/main/java/de/htwk/watchtime/network/ranking/RankingRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/ranking/RankingRepository.kt
@@ -1,0 +1,24 @@
+package de.htwk.watchtime.network.ranking
+
+import de.htwk.watchtime.data.Ranking
+
+interface RankingRepository {
+    suspend fun updateWatchtime(newTotalWatchtime: Long)
+    suspend fun getRanking(): Ranking
+    suspend fun deleteUser()
+}
+
+
+class RankingRepositoryImpl(private val dataSource: RemoteRankingDataSource) : RankingRepository {
+    override suspend fun updateWatchtime(newTotalWatchtime: Long) {
+        dataSource.updateWatchtime(newTotalWatchtime)
+    }
+
+    override suspend fun getRanking(): Ranking {
+        return dataSource.getRanking()
+    }
+
+    override suspend fun deleteUser() {
+        dataSource.deleteUser()
+    }
+}

--- a/app/src/main/java/de/htwk/watchtime/network/ranking/RemoteRankingDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/ranking/RemoteRankingDataSource.kt
@@ -13,10 +13,10 @@ interface RemoteRankingDataSource {
     suspend fun deleteUser()
 }
 
-class RemoteRankingDataSourceImpl: RemoteRankingDataSource {
+class RemoteRankingDataSourceImpl(private val deviceIdManager: DeviceIdManager): RemoteRankingDataSource {
     override suspend fun updateWatchtime(newTotalWatchtime: Long) {
         val apiKey = BuildConfig.AZURE_FUNCTION_KEY
-        val deviceId = UUID.randomUUID().toString()
+        val deviceId = deviceIdManager.getDeviceId()
 
         val rankingRequestBody = RankingRequest(deviceId, newTotalWatchtime)
         val updateWatchtimeResponse = rankingApi.updateWatchtime(apiKey, rankingRequestBody)
@@ -28,7 +28,7 @@ class RemoteRankingDataSourceImpl: RemoteRankingDataSource {
 
     override suspend fun getRanking(): Ranking {
         val apiKey = BuildConfig.AZURE_FUNCTION_KEY
-        val deviceId = UUID.randomUUID().toString()
+        val deviceId = deviceIdManager.getDeviceId()
 
         val rankingResponse = rankingApi.getRanking(apiKey, deviceId)
         val responseBody = rankingResponse.body()
@@ -42,7 +42,7 @@ class RemoteRankingDataSourceImpl: RemoteRankingDataSource {
 
     override suspend fun deleteUser() {
         val apiKey = BuildConfig.AZURE_FUNCTION_KEY
-        val deviceId = UUID.randomUUID().toString()
+        val deviceId = deviceIdManager.getDeviceId()
 
         val deleteResponse = rankingApi.deleteUser(apiKey, deviceId)
 

--- a/app/src/main/java/de/htwk/watchtime/network/ranking/RemoteRankingDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/ranking/RemoteRankingDataSource.kt
@@ -19,7 +19,6 @@ class RemoteRankingDataSourceImpl: RemoteRankingDataSource {
         val deviceId = UUID.randomUUID().toString()
 
         val rankingRequestBody = RankingRequest(deviceId, newTotalWatchtime)
-
         val updateWatchtimeResponse = rankingApi.updateWatchtime(apiKey, rankingRequestBody)
 
         if (!updateWatchtimeResponse.isSuccessful) {

--- a/app/src/main/java/de/htwk/watchtime/network/ranking/RemoteRankingDataSource.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/ranking/RemoteRankingDataSource.kt
@@ -1,0 +1,54 @@
+package de.htwk.watchtime.network.ranking
+
+import de.htwk.watchtime.BuildConfig
+import de.htwk.watchtime.data.Ranking
+import de.htwk.watchtime.network.NetworkRequestException
+import de.htwk.watchtime.network.dto.RankingRequest
+import de.htwk.watchtime.network.dto.toRanking
+import java.util.*
+
+interface RemoteRankingDataSource {
+    suspend fun updateWatchtime(newTotalWatchtime: Long)
+    suspend fun getRanking(): Ranking
+    suspend fun deleteUser()
+}
+
+class RemoteRankingDataSourceImpl: RemoteRankingDataSource {
+    override suspend fun updateWatchtime(newTotalWatchtime: Long) {
+        val apiKey = BuildConfig.AZURE_FUNCTION_KEY
+        val deviceId = UUID.randomUUID().toString()
+
+        val rankingRequestBody = RankingRequest(deviceId, newTotalWatchtime)
+
+        val updateWatchtimeResponse = rankingApi.updateWatchtime(apiKey, rankingRequestBody)
+
+        if (!updateWatchtimeResponse.isSuccessful) {
+            throw NetworkRequestException("Error updating watchtime")
+        }
+    }
+
+    override suspend fun getRanking(): Ranking {
+        val apiKey = BuildConfig.AZURE_FUNCTION_KEY
+        val deviceId = UUID.randomUUID().toString()
+
+        val rankingResponse = rankingApi.getRanking(apiKey, deviceId)
+        val responseBody = rankingResponse.body()
+
+        return if (rankingResponse.isSuccessful && responseBody != null)
+            responseBody.toRanking()
+        else {
+            throw NetworkRequestException("Error fetching ranking")
+        }
+    }
+
+    override suspend fun deleteUser() {
+        val apiKey = BuildConfig.AZURE_FUNCTION_KEY
+        val deviceId = UUID.randomUUID().toString()
+
+        val deleteResponse = rankingApi.deleteUser(apiKey, deviceId)
+
+        if (!deleteResponse.isSuccessful) {
+            throw NetworkRequestException("Error deleting user")
+        }
+    }
+}

--- a/app/src/main/java/de/htwk/watchtime/network/series/SeriesRepository.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/series/SeriesRepository.kt
@@ -1,10 +1,6 @@
-package de.htwk.watchtime.network
+package de.htwk.watchtime.network.series
 
-import de.htwk.watchtime.data.Episode
-import de.htwk.watchtime.data.ExtendedSeries
-import de.htwk.watchtime.data.Genre
-import de.htwk.watchtime.data.Season
-import de.htwk.watchtime.data.Series
+import de.htwk.watchtime.data.*
 
 interface SeriesRepository {
     suspend fun getSeries(): List<Series>
@@ -48,11 +44,11 @@ class SeriesRepositoryImpl(
         val seriesList = mutableListOf<Series>()
 
         seriesDtoList.forEach { seriesDto ->
-            if (seriesDto.type == "series"){
+            if (seriesDto.type == "series") {
                 seriesList.add(
                     Series(
                         name = seriesDto.name,
-                        year = seriesDto.year?.substring(0,4) ?: "unknown",
+                        year = seriesDto.year?.substring(0, 4) ?: "unknown",
                         imageUrl = seriesDto.imageUrl,
                         id = seriesDto.id,
                     )
@@ -74,13 +70,11 @@ class SeriesRepositoryImpl(
         }
 
         seriesDetails.seasons.forEach { seasonDto ->
-            seasonList[seasonDto.seasonNumber] = (
-                    Season(
-                        id = seasonDto.id,
-                        seasonNumber = seasonDto.seasonNumber,
-                        episodeIds = mutableListOf(),
-                    )
-                    )
+            seasonList[seasonDto.seasonNumber] = (Season(
+                id = seasonDto.id,
+                seasonNumber = seasonDto.seasonNumber,
+                episodeIds = mutableListOf(),
+            ))
         }
 
         seriesDetails.episodes.forEach { episodeDto ->
@@ -106,8 +100,7 @@ class SeriesRepositoryImpl(
             )
         }
 
-        val filteredSeasonList =
-            seasonList.filterKeys { seasonList[it]?.episodeIds?.isNotEmpty() ?: false }
+        val filteredSeasonList = seasonList.filterKeys { seasonList[it]?.episodeIds?.isNotEmpty() ?: false }
 
         return ExtendedSeries(
             name = seriesDetails.name,

--- a/app/src/main/java/de/htwk/watchtime/network/series/SessionManager.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/series/SessionManager.kt
@@ -1,4 +1,4 @@
-package de.htwk.watchtime.network
+package de.htwk.watchtime.network.series
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/app/src/main/java/de/htwk/watchtime/network/series/TvdbApi.kt
+++ b/app/src/main/java/de/htwk/watchtime/network/series/TvdbApi.kt
@@ -1,4 +1,4 @@
-package de.htwk.watchtime.network
+package de.htwk.watchtime.network.series
 
 import de.htwk.watchtime.network.dto.LoginRequest
 import de.htwk.watchtime.network.dto.LoginResponse
@@ -37,7 +37,6 @@ interface TvdbApi {
     suspend fun searchSeries(
         @Header("Authorization") authHeader: String,
         @Query("query") name: String
-
     ): Response<SearchResponse>
 
 }

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/DetailsScreen.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/DetailsScreen.kt
@@ -1,44 +1,20 @@
 package de.htwk.watchtime.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import android.widget.Toast
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material3.AssistChip
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.surfaceColorAtElevation
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -59,6 +35,14 @@ fun DetailsScreen(
     viewModel: DetailsViewModel = koinViewModel()
 ) {
     val detailsScreenUiState by viewModel.uiState.collectAsState()
+
+    val context = LocalContext.current
+    val lifecycle = LocalLifecycleOwner.current
+    viewModel.message.observe(lifecycle) {
+        it.getContentIfNotHandled()?.let { message ->
+            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+        }
+    }
 
     DetailsScreen(
         seriesDetails = detailsScreenUiState.seriesDetails,

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
@@ -7,7 +7,7 @@ import de.htwk.watchtime.data.ExtendedSeries
 import de.htwk.watchtime.data.Season
 import de.htwk.watchtime.data.uiState.DetailsScreenUiState
 import de.htwk.watchtime.database.WatchtimeRepository
-import de.htwk.watchtime.network.SeriesRepository
+import de.htwk.watchtime.network.series.SeriesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/DetailsViewModel.kt
@@ -1,12 +1,12 @@
 package de.htwk.watchtime.ui.screens.shared
 
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
+import de.htwk.watchtime.data.Event
 import de.htwk.watchtime.data.ExtendedSeries
 import de.htwk.watchtime.data.Season
 import de.htwk.watchtime.data.uiState.DetailsScreenUiState
 import de.htwk.watchtime.database.WatchtimeRepository
+import de.htwk.watchtime.network.ranking.RankingRepository
 import de.htwk.watchtime.network.series.SeriesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,8 +17,10 @@ class DetailsViewModel(
     savedStateHandle: SavedStateHandle,
     private val seriesRepository: SeriesRepository,
     private val watchtimeRepository: WatchtimeRepository,
+    private val rankingRepository: RankingRepository,
 ) : ViewModel() {
     private val seriesId: Int = checkNotNull(savedStateHandle.get<Int>("seriesId"))
+    private val errorOccurred = MutableLiveData<Event<String>>()
 
     private val _detailsScreenUiState: MutableStateFlow<DetailsScreenUiState> = MutableStateFlow(
         DetailsScreenUiState(
@@ -35,6 +37,8 @@ class DetailsViewModel(
         )
     )
     val uiState: StateFlow<DetailsScreenUiState> = _detailsScreenUiState
+    val message: LiveData<Event<String>>
+        get() = errorOccurred
 
     init {
         loadSeriesDetails()
@@ -228,6 +232,7 @@ class DetailsViewModel(
         }
 
         checkIfSeriesIsCompleted()
+        updateRanking()
     }
 
     private fun checkIfSeriesIsCompleted() {
@@ -245,6 +250,26 @@ class DetailsViewModel(
             // TODO: Optimize, so that DB is only updated if value actually changes
             viewModelScope.launch {
                 watchtimeRepository.updateSeriesCompletion(seriesId, newCompletionState)
+            }
+        }
+    }
+
+    private fun updateRanking() {
+        viewModelScope.launch {
+            val totalWatchtime = watchtimeRepository.getTotalWatchtime()
+            if (totalWatchtime == 0L) {
+                try {
+                    rankingRepository.deleteUser()
+                } catch (e: Exception) {
+                    errorOccurred.value = Event("Error deleting user from rankings")
+                }
+                return@launch
+            }
+
+            try {
+                rankingRepository.updateWatchtime(totalWatchtime)
+            } catch (e: Exception) {
+                errorOccurred.value = Event("Error updating rankings")
             }
         }
     }

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/HomeViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/HomeViewModel.kt
@@ -7,7 +7,7 @@ import de.htwk.watchtime.data.placeholder.placeHolderSeriesList
 import de.htwk.watchtime.data.toSeries
 import de.htwk.watchtime.data.uiState.HomeScreenUiState
 import de.htwk.watchtime.database.WatchtimeRepository
-import de.htwk.watchtime.network.SeriesRepository
+import de.htwk.watchtime.network.series.SeriesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/de/htwk/watchtime/ui/screens/shared/SearchViewModel.kt
+++ b/app/src/main/java/de/htwk/watchtime/ui/screens/shared/SearchViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import de.htwk.watchtime.data.Series
 import de.htwk.watchtime.database.WatchtimeRepository
-import de.htwk.watchtime.network.SeriesRepository
+import de.htwk.watchtime.network.series.SeriesRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/secrets.defaults.properties
+++ b/secrets.defaults.properties
@@ -1,1 +1,2 @@
 API_KEY=defaultInvalidApiKey
+AZURE_FUNCTION_KEY=defaultInvalidFunctionKey


### PR DESCRIPTION
## Changes
- Restructured Network Package
- On every update to the users total watchtime a PUT request is sent to the Azure Backend updating the total watchtime
- User is identified by a once-created UUID thats stored in SharedPreferences
- Network Errors are caught and now display a Toast Message (Only for the ranking Endpoint -> Should probably also be done for all other Network/DB requests))